### PR TITLE
Bump chart versions

### DIFF
--- a/helm-charts/app/Chart.yaml
+++ b/helm-charts/app/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "1.0"
 
 dependencies:
   - name: unnamed
-    version: 0.0.1-0.dev.git.153.h006ce20
+    version: 0.0.1-0.dev.git.168.h7074c29
     repository: https://2i2c.org/unnamed-thingity-thing/
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from
   # a single IP entrypoint to various services exposed via k8s Ingress resources

--- a/helm-charts/app/prod/prod.values.yaml
+++ b/helm-charts/app/prod/prod.values.yaml
@@ -1,8 +1,4 @@
 unnamed:
-  service:
-    type: ClusterIP
-    port: 8000
-
   ingress:
     enabled: true
     annotations:
@@ -15,10 +11,8 @@ unnamed:
         hosts:
           - cellmapchallenge.2i2c.cloud
 
-  # The nfs share /db/prod was created manually
-  nfs:
-    pv:
-      serverIP: 10.12.39.58
+  pvc:
+    storageClassName: premium-rwo
 
   adminUsers:
     - GeorgianaElena
@@ -29,6 +23,8 @@ unnamed:
     overrides:
       ALLOWED_HOSTS:
         - cellmapchallenge.2i2c.cloud
+      CSRF_TRUSTED_ORIGINS:
+        - https://cellmapchallenge.2i2c.cloud
       DEBUG: True
       SOCIALACCOUNT_PROVIDERS:
         github:

--- a/helm-charts/app/staging/staging.values.yaml
+++ b/helm-charts/app/staging/staging.values.yaml
@@ -1,8 +1,4 @@
 unnamed:
-  service:
-    type: ClusterIP
-    port: 8000
-
   ingress:
     enabled: true
     annotations:
@@ -15,10 +11,9 @@ unnamed:
         hosts:
           - staging.cellmapchallenge.2i2c.cloud
 
-  # The nfs share /db/staging was created manually
-  nfs:
-    pv:
-      serverIP: 10.12.39.58
+
+  pvc:
+    storageClassName: premium-rwo
 
   adminUsers:
     - GeorgianaElena
@@ -28,6 +23,8 @@ unnamed:
     overrides:
       ALLOWED_HOSTS:
         - staging.cellmapchallenge.2i2c.cloud
+      CSRF_TRUSTED_ORIGINS:
+        - https://staging.cellmapchallenge.2i2c.cloud
       DEBUG: True
       SOCIALACCOUNT_PROVIDERS:
         github:

--- a/helm-charts/app/staging/staging.values.yaml
+++ b/helm-charts/app/staging/staging.values.yaml
@@ -11,7 +11,6 @@ unnamed:
         hosts:
           - staging.cellmapchallenge.2i2c.cloud
 
-
   pvc:
     storageClassName: premium-rwo
 


### PR DESCRIPTION
- Switch to using PVCs, not NFS, to store DB
- Don't specify service info that's same as default in the chart